### PR TITLE
Vector Search Demo Side-By-Side View

### DIFF
--- a/src/api/textSearch.ts
+++ b/src/api/textSearch.ts
@@ -27,40 +27,44 @@ export const getTextSearchResults = async (
     vector: number[],
     approach: string,
     searchQuery: string,
-    useSemanticRanker: boolean,
     useSemanticCaptions: boolean,
     filterText: string
 ): Promise<SearchResponse<TextSearchResult>> => {
     const payload: SearchRequest = {
-        vector: {
-            value: vector,
-            // Change your desired fields here
-            fields: "contentVector",
-            k: 10
-        }
         // Optionally, select parameters to reduce the response payload size
         // select: "title, content, category",
     };
 
-    if (approach === "hs") {
+    if (!approach || approach === "text") {
         payload.search = searchQuery;
-    }
+    } else {
+        payload.vector = {
+            value: vector,
+            // Change your desired fields here
+            fields: "contentVector",
+            k: 10
+        };
 
-    if (approach === "vecf") {
-        payload.filter = filterText;
-    }
+        if (approach === "hs") {
+            payload.search = searchQuery;
+        }
 
-    if (useSemanticRanker) {
-        payload.queryType = "semantic";
-        payload.queryLanguage = "en-us";
-        payload.semanticConfiguration = "my-semantic-config";
-    }
+        if (approach === "vecf") {
+            payload.filter = filterText;
+        }
 
-    if (useSemanticCaptions) {
-        payload.captions = "extractive";
-        payload.answers = "extractive";
-        payload.highlightPreTag = "<b>";
-        payload.highlightPostTag = "</b>";
+        if (approach === "hssr") {
+            payload.search = searchQuery;
+            payload.queryType = "semantic";
+            payload.queryLanguage = "en-us";
+            payload.semanticConfiguration = "my-semantic-config";
+            if (useSemanticCaptions) {
+                payload.captions = "extractive";
+                payload.answers = "extractive";
+                payload.highlightPreTag = "<b>";
+                payload.highlightPostTag = "</b>";
+            }
+        }
     }
 
     const url = `${import.meta.env.VITE_SEARCH_SERVICE_ENDPOINT}/indexes/${import.meta.env.VITE_SEARCH_TEXT_INDEX_NAME}/docs/search?api-version=${

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,5 +1,5 @@
 export interface SearchRequest {
-    vector: {
+    vector?: {
         value: number[];
         fields: string;
         k: number;
@@ -63,4 +63,22 @@ export interface TextEmbeddingResponse {
 
 export interface ImageEmbeddingResponse {
     vector: number[];
+}
+
+export interface Approach {
+    key: string;
+    text: string;
+}
+
+export interface ResultCard {
+    approachKey: string;
+    searchResults: TextSearchResult[];
+    semanticAnswer: SemanticAnswer | null;
+}
+
+export interface AxiosErrorResponseData {
+    error: {
+        code: string;
+        message: string;
+    };
 }

--- a/src/pages/Vector/Vector.module.css
+++ b/src/pages/Vector/Vector.module.css
@@ -53,6 +53,7 @@
     padding: 10px;
     background: white;
     display: flex;
+    margin-bottom: 5px;
 }
 
 .textContainer {
@@ -99,4 +100,20 @@
     gap: 10px;
     flex: 1;
     justify-content: center;
+}
+
+.retrievalMode {
+    font-size: 14px;
+    margin-top: 5px;
+    font-weight: bold;
+}
+
+.checkboxSemanticCaption {
+    margin-top: 15px;
+    margin-left: 15px;
+}
+
+.approach {
+    font-size: 18px;
+    margin-left: 10px;
 }


### PR DESCRIPTION
This PR:

- Adds a new 'Text Only' retrieval mode and sets it as the default retrieval mode.
- Changes single-selection to multi-selection in the retrieval mode settings.
- Displays results retrieved from different approaches side by side.
- Adds a toggle to hide/show scores of the results.
- Handles errors from the API calls.


<img width="179" alt="image" src="https://github.com/farzad528/azure-search-vector-search-demo/assets/140462121/237290c6-b0fc-4651-a6a8-2443775e12cb">

<img width="929" alt="image" src="https://github.com/farzad528/azure-search-vector-search-demo/assets/140462121/ebe608f7-ba84-4612-95ae-f806568d936e">

![image](https://github.com/farzad528/azure-search-vector-search-demo/assets/140462121/8115bc7d-71e6-4939-9a88-c191c6153921)